### PR TITLE
Fixed python requirements.txt

### DIFF
--- a/skule_vote/requirements.txt
+++ b/skule_vote/requirements.txt
@@ -31,7 +31,7 @@ regex==2021.4.4
 requests==2.25.1
 ruamel.yaml==0.17.4
 ruamel.yaml.clib==0.2.2
-setuptools==52.0.0.post20210125
+setuptools==52.0.0
 sqlparse==0.4.1
 toml==0.10.2
 uritemplate==3.0.1


### PR DESCRIPTION
## Overview

- Resolves #16
- @arminale mentioned error with `setuptools` install. Fixed it by removing extra text at the end of setuptools version.


## Unit Tests Created

- None


## Steps to QA

- Run `pip install -r requirements.txt` and ensure it works

