### PR TITLE
Add useLocalStorage hook

### DIFF
--- a/skule_vote/frontend/ui/package.json
+++ b/skule_vote/frontend/ui/package.json
@@ -8,6 +8,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
+    "@testing-library/react-hooks": "^7.0.0",
     "@testing-library/user-event": "^12.1.10",
     "prettier": "^2.3.0",
     "react": "^17.0.2",

--- a/skule_vote/frontend/ui/src/App.js
+++ b/skule_vote/frontend/ui/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { createMuiTheme } from "@material-ui/core/styles";
@@ -11,6 +11,7 @@ import NotFound from "pages/NotFound";
 import Footer from "components/Footer";
 import Header from "components/Header";
 import { responsive } from "assets/breakpoints";
+import { useLocalStorage } from "assets/hooks";
 
 const AppWrapper = styled.div`
   min-height: 100vh;
@@ -46,9 +47,12 @@ const AppBody = styled.div`
 
 const App = () => {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
-  const [darkState, setDarkState] = useState(prefersDarkMode);
+  const [isDark, setIsDark] = useLocalStorage(
+    "prefersDarkMode",
+    prefersDarkMode
+  );
   const toggleDark = () => {
-    setDarkState(!darkState);
+    setIsDark(!isDark);
   };
 
   const theme = React.useMemo(
@@ -90,28 +94,28 @@ const App = () => {
           },
         },
         palette: {
-          type: darkState ? "dark" : "light",
+          type: isDark ? "dark" : "light",
           primary: {
             main: "#3B739E",
           },
           secondary: {
-            main: darkState ? "#C8EDFF" : "#3B6482",
+            main: isDark ? "#C8EDFF" : "#3B6482",
           },
           background: {
-            default: darkState ? "#212121 !important" : "#EFEFEF !important",
+            default: isDark ? "#212121 !important" : "#EFEFEF !important",
           },
         },
       }),
-    [darkState]
+    [isDark]
   );
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <BrowserRouter>
-        <AppWrapper theme={theme} isDark={darkState}>
+        <AppWrapper theme={theme} isDark={isDark}>
           <div>
-            <Header isDark={darkState} toggleDark={toggleDark} />
+            <Header isDark={isDark} toggleDark={toggleDark} />
             <AppBody>
               <Switch>
                 <Route exact path="/" component={LandingPage} />
@@ -121,7 +125,7 @@ const App = () => {
               </Switch>
             </AppBody>
           </div>
-          <Footer isDark={darkState} />
+          <Footer isDark={isDark} />
         </AppWrapper>
       </BrowserRouter>
     </ThemeProvider>

--- a/skule_vote/frontend/ui/src/assets/__tests__/hooks.test.js
+++ b/skule_vote/frontend/ui/src/assets/__tests__/hooks.test.js
@@ -1,0 +1,65 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useLocalStorage } from "assets/hooks";
+
+describe("useLocalStorage", () => {
+  it("return value as undefined if not specified", () => {
+    const { result } = renderHook(() => useLocalStorage("KEY"));
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it("renderz initial value and updates localStorage values", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    const { result } = renderHook(() => useLocalStorage("KEY", "INIT_VAL"));
+
+    let [val, setVal] = result.current;
+    expect(val).toBe("INIT_VAL");
+
+    act(() => setVal("NEW_VAL"));
+    [val, setVal] = result.current;
+    expect(val).toBe("NEW_VAL");
+
+    expect(setItemSpy).toHaveBeenCalledWith("KEY", JSON.stringify("NEW_VAL"));
+    expect(window.localStorage.getItem("KEY")).toBe(JSON.stringify("NEW_VAL"));
+
+    setItemSpy.mockRestore();
+  });
+
+  it("uses previously stored value in localStorage instead of initial value parameter", () => {
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => JSON.stringify("PRE_EXISTING"));
+
+    const { result } = renderHook(() => useLocalStorage("KEY", "INIT_VAL"));
+    expect(getItemSpy).toHaveBeenCalledWith("KEY");
+
+    const [value] = result.current;
+    expect(value).toBe("PRE_EXISTING");
+    expect(window.localStorage.getItem("KEY")).toBe(
+      JSON.stringify("PRE_EXISTING")
+    );
+
+    getItemSpy.mockRestore();
+  });
+
+  it("clears and removes item from localStorage", () => {
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => JSON.stringify("PRE_EXISTING"));
+    const removeItemSpy = jest
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useLocalStorage("KEY", "INIT_VAL"));
+
+    let [value, , remove] = result.current;
+    expect(value).toBe("PRE_EXISTING");
+    act(() => remove());
+
+    [value, , remove] = result.current;
+    expect(value).toBeUndefined();
+    expect(removeItemSpy).toHaveBeenCalledWith("KEY");
+
+    getItemSpy.mockRestore();
+    removeItemSpy.mockRestore();
+  });
+});

--- a/skule_vote/frontend/ui/src/assets/hooks.js
+++ b/skule_vote/frontend/ui/src/assets/hooks.js
@@ -1,0 +1,31 @@
+import { useState, useCallback } from "react";
+
+export function useLocalStorage(key, initValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initValue;
+    } catch (error) {
+      return initValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (value) => {
+      try {
+        setStoredValue(value);
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } catch (error) {
+        //   handle
+      }
+    },
+    [key]
+  );
+
+  const removeKey = useCallback(() => {
+    window.localStorage.removeItem(key);
+    setStoredValue(undefined);
+  }, [key]);
+
+  return [storedValue, setValue, removeKey];
+}

--- a/skule_vote/frontend/ui/yarn.lock
+++ b/skule_vote/frontend/ui/yarn.lock
@@ -1777,6 +1777,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz#dd6d37a7e018f147a3b9153137f10e013be8472b"
+  integrity sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.1.0":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -1945,6 +1956,20 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.5.tgz#df44eed5b8d9e0b13bb0cd38e0ea6572a1231227"
+  integrity sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.2.0":
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
@@ -1956,6 +1981,15 @@
   version "17.0.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.5.tgz#3d887570c4489011f75a3fc8f965bf87d09a1bea"
   integrity sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.8.tgz#fe76e3ba0fbb5602704110fd1e3035cf394778e3"
+  integrity sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -9340,6 +9374,13 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
## Overview

- Resolves #68 
- Resolves #40 (oops I made 2 issues)
- Currently, your laptop knows if you have a preference of light mode of dark mode (idk how/where it is set though)
- The default dark/light mode on the site is set at that saved preference
- However, once you change to the opposite mode and refresh the page, you should notice that it goes back to your default mode
- This PR saves your most previous used mode in local storage, that way if you refresh or come back months later, it will remember which mode you set it to last


## Unit Tests Created

- Tests useLocalStorage hook gets, removes, sets properly in local storage


## Steps to QA

- Run `yarn in`
- Once the frontend renders, take a note of the mode. That is your default preferred mode.
- In the applications tab of the inspect element, check your local storage. It should be empty. Keep the local storage tab open
- Change to the opposite mode, your local storage should look like this (the value should be false if it changed to light mode)
<img width="569" alt="Screen Shot 2021-05-31 at 11 35 37 AM" src="https://user-images.githubusercontent.com/42653157/120215955-61b76a00-c204-11eb-9a67-633ab82c8d69.png">

- Alternate between dark mode and light mode, the local storage item should update accordingly 
- Mess around
  - Open a second tab, change the mode, refresh both tabs, make sure the color on both tabs should be the most recent one
  - Close the window, reopen, should be the same

