### PR TITLE
Style cookie bypass form

### DIFF
--- a/skule_vote/backend/templates/cookieform.html
+++ b/skule_vote/backend/templates/cookieform.html
@@ -48,7 +48,7 @@
         <div class="row">
             <div class="col s12" style="padding: 0; margin-bottom: 0;">
                 <div class="input-field" style="margin-bottom: 0;">
-                    <input placeholder="Student ID Hash" value="213asdf2348u9" maxlength="16" class="validate" type="text" name="pid" id="pid" required="required" aria-required="true">
+                    <input placeholder="Student ID Hash" value="213asdf2348u9" maxlength="16" class="validate" type="text" name="pid" id="pid" required>
                     <label for="pid">Student ID Hash*</label>
                     <span class="helper-text">Assumed to be unique per person. Will overwrite old info</span>
                 </div>
@@ -60,13 +60,13 @@
         <div class="radio-group">
             <p>
                 <label for="isstudent-0">
-                    <input class="with-gap" name="isstudent" id="isstudent-0" required="required" aria-required="true" value="True" type="radio" checked>
+                    <input class="with-gap" name="isstudent" id="isstudent-0" value="True" type="radio" checked required>
                     <span>Yes</span>
                 </label>
             </p>
             <p>
                 <label for="isstudent-1">
-                    <input class="with-gap" name="isstudent" id="isstudent-1" required="required" aria-required="true" value="False" type="radio">
+                    <input class="with-gap" name="isstudent" id="isstudent-1" value="False" type="radio" required>
                     <span>No</span>
                 </label>
             </p>
@@ -77,13 +77,13 @@
         <div class="radio-group">
             <p>
                 <label for="primaryorg-0">
-                    <input class="with-gap" name="primaryorg" id="primaryorg-0" required="required" aria-required="true" value="APSE" type="radio" checked>
+                    <input class="with-gap" name="primaryorg" id="primaryorg-0" value="APSE" type="radio" checked required>
                     <span>Yes</span>
                 </label>
             </p>
             <p>
                 <label for="primaryorg-1">
-                    <input class="with-gap" name="primaryorg" id="primaryorg-1" required="required" aria-required="true" value="null" type="radio">
+                    <input class="with-gap" name="primaryorg" id="primaryorg-1" value="null" type="radio" required>
                     <span>No</span>
                 </label>
             </p>
@@ -94,13 +94,13 @@
         <div class="radio-group">
             <p>
                 <label for="isundergrad-0">
-                    <input class="with-gap" name="isundergrad" id="isundergrad-0" required="required" aria-required="true" value="True" type="radio" checked>
+                    <input class="with-gap" name="isundergrad" id="isundergrad-0" value="True" type="radio" checked required>
                     <span>Yes</span>
                 </label>
             </p>
             <p>
                 <label for="isundergrad-1">
-                    <input class="with-gap" name="isundergrad" id="isundergrad-1" required="required" aria-required="true" value="False" type="radio">
+                    <input class="with-gap" name="isundergrad" id="isundergrad-1" value="False" type="radio" required>
                     <span>No</span>
                 </label>
             </p>
@@ -111,13 +111,13 @@
         <div class="radio-group">
             <p>
                 <label for="isregistered-0">
-                    <input class="with-gap" name="isregistered" id="isregistered-0" required="required" aria-required="true" value="True" type="radio" checked>
+                    <input class="with-gap" name="isregistered" id="isregistered-0" value="True" type="radio" checked required>
                     <span>Yes</span>
                 </label>
             </p>
             <p>
                 <label for="isregistered-1">
-                    <input class="with-gap" name="isregistered" id="isregistered-1" required="required" aria-required="true" value="False" type="radio">
+                    <input class="with-gap" name="isregistered" id="isregistered-1" value="False" type="radio" required>
                     <span>No</span>
                 </label>
             </p>
@@ -128,13 +128,13 @@
         <div class="radio-group">
             <p>
                 <label for="assocorg-0">
-                    <input class="with-gap" name="assocorg" id="assocorg-0" required="required" aria-required="true" value="AEPEY" type="radio">
+                    <input class="with-gap" name="assocorg" id="assocorg-0" value="AEPEY" type="radio" required>
                     <span>Yes</span>
                 </label>
             </p>
             <p>
                 <label for="assocorg-1">
-                    <input class="with-gap" name="assocorg" id="assocorg-1" required="required" aria-required="true" value="null" type="radio" checked>
+                    <input class="with-gap" name="assocorg" id="assocorg-1" value="null" type="radio" checked required>
                     <span>No</span>
                 </label>
             </p>
@@ -145,25 +145,25 @@
         <div class="radio-group">
             <p>
                 <label for="yofstudy-0">
-                    <input class="with-gap" name="yofstudy" id="yofstudy-0" required="required" value="1" type="radio" checked>
+                    <input class="with-gap" name="yofstudy" id="yofstudy-0" value="1" type="radio" checked required>
                     <span>1</span>
                 </label>
             </p>
             <p>
                 <label for="yofstudy-1">
-                    <input class="with-gap" name="yofstudy" id="yofstudy-1" required="required" value="2" type="radio">
+                    <input class="with-gap" name="yofstudy" id="yofstudy-1" value="2" type="radio" required>
                     <span>2</span>
                 </label>
             </p>
             <p>
                 <label for="yofstudy-2">
-                    <input class="with-gap" name="yofstudy" id="yofstudy-2" required="required" value="3" type="radio">
+                    <input class="with-gap" name="yofstudy" id="yofstudy-2" value="3" type="radio" required>
                     <span>3</span>
                 </label>
             </p>
             <p>
                 <label for="yofstudy-3">
-                    <input class="with-gap" name="yofstudy" id="yofstudy-3" required="required" value="4" type="radio">
+                    <input class="with-gap" name="yofstudy" id="yofstudy-3" value="4" type="radio" required>
                     <span>4</span>
                 </label>
             </p>
@@ -174,13 +174,13 @@
         <div class="radio-group">
             <p>
                 <label for="attendance-0">
-                    <input class="with-gap" name="attendance" id="attendance-0" required="required" aria-required="true" value="FT" type="radio" checked>
+                    <input class="with-gap" name="attendance" id="attendance-0" value="FT" type="radio" checked required>
                     <span>Full-time</span>
                 </label>
             </p>
             <p>
                 <label for="attendance-1">
-                    <input class="with-gap" name="attendance" id="attendance-1" required="required" aria-required="true" value="PT" type="radio">
+                    <input class="with-gap" name="attendance" id="attendance-1" value="PT" type="radio" required>
                     <span>Part-time</span>
                 </label>
             </p>
@@ -191,19 +191,19 @@
         <div class="radio-group">
             <p>
                 <label for="campus-0">
-                    <input class="with-gap" name="campus" id="campus-0" required="required" aria-required="true" value="utsg" type="radio" checked>
+                    <input class="with-gap" name="campus" id="campus-0" value="utsg" type="radio" checked required>
                     <span>UTSG</span>
                 </label>
             </p>
             <p>
                 <label for="campus-1">
-                    <input class="with-gap" name="campus" id="campus-1" required="required" aria-required="true" value="utm" type="radio">
+                    <input class="with-gap" name="campus" id="campus-1" value="utm" type="radio" required>
                     <span>UTM</span>
                 </label>
             </p>
             <p>
                 <label for="campus-2">
-                    <input class="with-gap" name="campus" id="campus-2" required="required" aria-required="true" value="utsc" type="radio">
+                    <input class="with-gap" name="campus" id="campus-2" value="utsc" type="radio" required>
                     <span>UTSC</span>
                 </label>
             </p>
@@ -215,55 +215,55 @@
         <div class="radio-group">
             <p>
                 <label for="postcd-0">
-                    <input class="with-gap" name="postcd" id="postcd-0" required="required" aria-required="true" value="AEESCBLAH" type="radio" checked>
+                    <input class="with-gap" name="postcd" id="postcd-0" value="AEESCBLAH" type="radio" checked required>
                     <span>EngSci</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-1">
-                    <input class="with-gap" name="postcd" id="postcd-1" required="required" aria-required="true" value="AEELEBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-1" value="AEELEBLAH" type="radio" required>
                     <span>Elec</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-2">
-                    <input class="with-gap" name="postcd" id="postcd-2" required="required" aria-required="true" value="AECPEBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-2" value="AECPEBLAH" type="radio" required>
                     <span>Comp</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-3">
-                    <input class="with-gap" name="postcd" id="postcd-3" required="required" aria-required="true" value="AEMECBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-3" value="AEMECBLAH" type="radio" required>
                     <span>Mech</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-4">
-                    <input class="with-gap" name="postcd" id="postcd-4" required="required" aria-required="true" value="AECHEBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-4" value="AECHEBLAH" type="radio" required>
                     <span>Chem</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-5">
-                    <input class="with-gap" name="postcd" id="postcd-5" required="required" aria-required="true" value="AEINDBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-5" value="AEINDBLAH" type="radio" required>
                     <span>Indy</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-6">
-                    <input class="with-gap" name="postcd" id="postcd-6" required="required" aria-required="true" value="AEMMSBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-6" value="AEMMSBLAH" type="radio" required>
                     <span>MSE</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-7">
-                    <input class="with-gap" name="postcd" id="postcd-7" required="required" aria-required="true" value="AELMEBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-7" value="AELMEBLAH" type="radio" required>
                     <span>Min</span>
                 </label>
             </p>
             <p>
                 <label for="postcd-8">
-                    <input class="with-gap" name="postcd" id="postcd-8" required="required" aria-required="true" value="AEENGBLAH" type="radio">
+                    <input class="with-gap" name="postcd" id="postcd-8" value="AEENGBLAH" type="radio" required>
                     <span>Trackone</span>
                 </label>
             </p>


### PR DESCRIPTION
## Overview

- Resolves #73 
- Simple styling with some Materialize
- Check radio buttons by default so you click less

Before:
<img width="759" alt="Screen Shot 2021-07-19 at 4 07 49 PM" src="https://user-images.githubusercontent.com/42653157/126234144-95333013-3d1f-43ed-907c-813cb296af16.png">

After:
![screencapture-localhost-8000-api-bypasscookie-2021-07-19-16_13_12](https://user-images.githubusercontent.com/42653157/126234184-d0f40b3b-e100-4a59-887e-3d75ae9113b2.png)

## Unit Tests Created

N/A


## Steps to QA

- Set up an active election session with the default CSVs
- Go to http://localhost:8000/api/bypasscookie, fill out the form, submit it, ensure the response from the API contains the elections the "student" you entered in the form would see
- You can double confirm that you see those elections on http://localhost:3000/elections

