### PR TITLE
Ballot and Voter Admin Site Save/Change/View/Delete Restrictions

### DIFF
--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -140,7 +140,36 @@ class CandidateAdmin(admin.ModelAdmin):
 
 @admin.register(Voter)
 class VoterAdmin(admin.ModelAdmin):
-    pass
+    if not settings.DEBUG:
+        actions = None
+
+    # We cannot call super().get_fields(request, obj) because that method calls
+    # get_readonly_fields(request, obj), causing infinite recursion. Ditto for
+    # super().get_form(request, obj). So we  assume the default ModelForm.
+    def get_readonly_fields(self, request, obj=None):
+        if settings.DEBUG:
+            return super().get_readonly_fields(request, obj)
+        return self.fields or [f.name for f in self.model._meta.fields]
+
+    def has_add_permission(self, request):
+        if settings.DEBUG:
+            return super().has_add_permission(request)
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_change_permission(request, obj)
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_delete_permission(request, obj)
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_view_permission(request, obj)
+        return True
 
 
 class BallotResource(resources.ModelResource):
@@ -176,6 +205,36 @@ class BallotResource(resources.ModelResource):
 @admin.register(Ballot)
 class BallotAdmin(ExportMixin, admin.ModelAdmin):
     resource_class = BallotResource
+    if not settings.DEBUG:
+        actions = None
+
+    # We cannot call super().get_fields(request, obj) because that method calls
+    # get_readonly_fields(request, obj), causing infinite recursion. Ditto for
+    # super().get_form(request, obj). So we  assume the default ModelForm.
+    def get_readonly_fields(self, request, obj=None):
+        if settings.DEBUG:
+            return super().get_readonly_fields(request, obj)
+        return self.fields or [f.name for f in self.model._meta.fields]
+
+    def has_add_permission(self, request):
+        if settings.DEBUG:
+            return super().has_add_permission(request)
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_change_permission(request, obj)
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_delete_permission(request, obj)
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        if settings.DEBUG:
+            return super().has_view_permission(request, obj)
+        return True
 
 
 @admin.register(Eligibility)

--- a/skule_vote/skule_vote/tests.py
+++ b/skule_vote/skule_vote/tests.py
@@ -7,15 +7,19 @@ import string
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 
 from backend.forms import ElectionSessionAdminForm
 
 from backend.models import (
     DISCIPLINE_CHOICES,
     STUDY_YEAR_CHOICES,
+    Ballot,
+    Candidate,
     Election,
     ElectionSession,
     Eligibility,
+    Voter,
 )
 
 User = get_user_model()
@@ -379,6 +383,41 @@ class SetupMixin:
             )
 
         return file_dict
+
+    def _generate_voters(self, count=4):
+        voters = []
+        cookie_view = reverse("api:backend:bypass-cookie")
+
+        for i in range(count):
+            voter = self._urlencode_cookie_request(year=(i % 4) + 1)
+            voters.append(voter)
+            self.client.post(cookie_view, voter, follow=True)
+        return voters
+
+    def _generate_ron_ballots(self, max_ballots=4, voter_count=4, voters=None):
+        if voters is None:
+            voters = self._generate_voters(count=voter_count)
+        if Candidate.objects.count() == 0:
+            self._set_election_session_data()
+            election_session = self._create_election_session(self.data)
+            self.setUpElections(election_session)
+
+        ballots = []
+        ballot_count = 0
+        for voter in Voter.objects.all():
+            for candidate in Candidate.objects.all():
+                ballot = Ballot(
+                    voter=voter,
+                    candidate=candidate,
+                    rank=1,
+                    election=candidate.election,
+                )
+                ballot.save()
+                ballots.append(ballot)
+                ballot_count += 1
+                if ballot_count >= max_ballots:
+                    return ballots
+        return ballots
 
     @staticmethod
     def _now():

--- a/skule_vote/skule_vote/tests.py
+++ b/skule_vote/skule_vote/tests.py
@@ -409,7 +409,7 @@ class SetupMixin:
                 ballot = Ballot(
                     voter=voter,
                     candidate=candidate,
-                    rank=1,
+                    rank=0,
                     election=candidate.election,
                 )
                 ballot.save()


### PR DESCRIPTION
## Overview

- Resolves #24
- Whoops I named the branch wrong my bad it should be `24-ballot-voter-restrictions`
- Ensures that `Voters` and `Ballots` will only be visible and not editable/deleteable in production, while maintaining full editability and deletability in development.
- When viewing the `changelist` view for `Voters` and `Ballots`:
    - If  `DEBUG=1` then you will see the changelist as normal and you can add or change `Ballots` or `Voters`. Text at the top will read "Select Ballot/Voter to change"
    - Otherwise, in production you will see the changelist without the ability to add a `Voter` or `Ballot`. Text at the top will read "Select Ballot/Voter to view"
- When viewing the `change` view for `Voters` and `Ballots`:
    - If  `DEBUG=1` then you will see everything about the `Ballots` or `Voters` like normal. You should be able to save any changes you make to the `Ballot` or `Voter` and also delete the `Ballot or `Voter`. Text at the top will read "Change ballot/voter"
    - Otherwise, in production you will see the information about the `Voter` or `Ballot` like usual but without the ability to change it. You should not see the delete or any of the save buttons. Text at the top will read "View ballot/voter".

## Unit Tests Created

- Corresponding unit tests created for in prod and in development (`DEBUG=1`) for the following:
    - `Voters` and `Ballots` render properly in the `changelist` view.
    - `Voters` and `Ballots` render the `Save` and `Delete` button properly in their `change` views.


## Steps to QA

- Similar tests as #80. Take a look at that PR and do the same thing with the `Voter` and `Ballot`. You will need to go create some `Voter` and `Ballot` entries in the db and then enter "prod mode" in the same way.

