### PR TITLE
Create new style for filled purple button

### DIFF
--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -13,7 +13,6 @@ import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import { Spacer } from "assets/layout";
-import { useHandleSubmit } from "hooks/ElectionHooks";
 import { CustomMessage } from "components/Alerts";
 import { responsive } from "assets/breakpoints";
 import { useTheme } from "@material-ui/core/styles";
@@ -115,6 +114,14 @@ const ErrorText = styled(Typography)`
 const SpoilBallotBtn = styled(Button)`
   color: ${(props) => (props.$isDark ? "#DCD1DD" : "#4D33A3")};
   border-color: ${(props) => (props.$isDark ? "#DCD1DD" : "#4D33A3")};
+`;
+
+const SpoilBallotBtnFilled = styled(Button)`
+  color: #fff;
+  background-color: #5f518d;
+  :hover {
+    background-color: #51496b;
+  }
 `;
 
 const BlueCard = styled.div`
@@ -388,15 +395,14 @@ export const ConfirmSpoilModal = ({ open, onClose, spoilBallot, isDark }) => (
         >
           Cancel
         </Button>
-        <SpoilBallotBtn
-          $isDark={isDark}
-          variant="outlined"
+        <SpoilBallotBtnFilled
+          variant="contained"
           onClick={() => spoilBallot()}
           data-testid="spoilModalConfirm"
           disableElevation
         >
           Spoil ballot
-        </SpoilBallotBtn>
+        </SpoilBallotBtnFilled>
       </TwoButtonDiv>
     </SpoilModalPaper>
   </Modal>


### PR DESCRIPTION
## Overview

Before:
<img width="465" alt="Screen Shot 2021-09-13 at 9 46 25 PM" src="https://user-images.githubusercontent.com/42653157/133181067-3931a328-91ef-4eed-b625-b32643361896.png">
<img width="522" alt="Screen Shot 2021-09-13 at 9 46 35 PM" src="https://user-images.githubusercontent.com/42653157/133181068-be0e7f9f-0bcd-49bc-98f6-d10c76fc59b6.png">


After:
<img width="480" alt="Screen Shot 2021-09-13 at 9 45 30 PM" src="https://user-images.githubusercontent.com/42653157/133180977-63949ce5-1785-443c-8cc1-ef5e14f98c7e.png">
<img width="476" alt="Screen Shot 2021-09-13 at 9 45 09 PM" src="https://user-images.githubusercontent.com/42653157/133180990-f496501b-e2ba-4a4d-b86c-e5921114e51d.png">

## Unit Tests Created

N/A


## Steps to QA

- Spoil a ballot on dark and light mode

