### PR TITLE
Added civ to cookie bypass form

### DIFF
--- a/skule_vote/backend/templates/cookieform.html
+++ b/skule_vote/backend/templates/cookieform.html
@@ -267,6 +267,12 @@
                     <span>Trackone</span>
                 </label>
             </p>
+            <p>
+                <label for="postcd-9">
+                    <input class="with-gap" name="postcd" id="postcd-9" value="AECIVBLAH" type="radio" required>
+                    <span>Civil</span>
+                </label>
+            </p>
         </div>
     </div>
     <div style="display: flex; justify-content: center;">


### PR DESCRIPTION
## Overview

- Resolves #112
- Added a radio button for cookie bypass form


## Unit Tests Created

- None


## Steps to QA

- Go to the cookie bypass view. Make sure civil is there
- Submit the bypass view with discipline as civil. Make sure a voter object is created with the civil discipline and is able to see civil elections

