### PR TITLE
Calculate Results Action

### DIFF
--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -62,7 +62,7 @@ class ElectionSessionAdmin(admin.ModelAdmin):
 
     change_list_template = "election-session/change_list.html"
 
-    actions = ['generate_results']
+    actions = ["generate_results"]
 
     @admin.action(description="Generate results for selected ElectionSessions")
     def generate_results(self, request, queryset):
@@ -92,7 +92,9 @@ class ElectionSessionAdmin(admin.ModelAdmin):
                     choices=choices_dict,
                     numSeats=election.seats_available,
                 )
-            election_session_results[f"{election_session.election_session_name} ElectionSession"] = election_results
+            election_session_results[
+                f"{election_session.election_session_name} ElectionSession"
+            ] = election_results
 
         return JsonResponse(election_session_results)
 

--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -1,8 +1,11 @@
 from django.conf import settings
 from django.contrib import admin
+from django.http import JsonResponse
+
 from import_export import resources
 from import_export.admin import ExportMixin
 
+from backend.ballot import calculate_results
 from backend.forms import ElectionSessionAdminForm
 from backend.models import (
     ElectionSession,
@@ -12,6 +15,10 @@ from backend.models import (
     Ballot,
     Eligibility,
     Message,
+)
+from backend.serializers import (
+    BallotResultsCalculationSerializer as BallotSerializer,
+    CandidateSerializer,
 )
 
 
@@ -54,6 +61,40 @@ class ElectionSessionAdmin(admin.ModelAdmin):
     form = ElectionSessionAdminForm
 
     change_list_template = "election-session/change_list.html"
+
+    actions = ['generate_results']
+
+    @admin.action(description="Generate results for selected ElectionSessions")
+    def generate_results(self, request, queryset):
+
+        election_session_results = {}
+        for election_session in queryset:
+            elections = Election.objects.filter(election_session=election_session)
+            election_results = {}
+            for election in elections:
+                election_ballots = Ballot.objects.filter(election=election)
+                election_candidates = Candidate.objects.filter(election=election)
+
+                # Ballot dict contains Candidate objects, we need indicies from the Candidates list.
+                ballot_serializer = BallotSerializer(election_ballots)
+                election_ballots_formatted = (
+                    ballot_serializer.map_candidates_in_ballots_to_choices(
+                        ballots=ballot_serializer.data, choices=election_candidates
+                    )
+                )
+                # The choice array is a queryset, we need a dictionary
+                choices_dict = CandidateSerializer(election_candidates, many=True).data
+                for i in range(len(choices_dict)):
+                    choices_dict[i] = dict(choices_dict[i])
+
+                election_results[f"{election.election_name}"] = calculate_results(
+                    ballots=election_ballots_formatted,
+                    choices=choices_dict,
+                    numSeats=election.seats_available,
+                )
+            election_session_results[f"{election_session.election_session_name} ElectionSession"] = election_results
+
+        return JsonResponse(election_session_results)
 
 
 @admin.register(Election)

--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -1,6 +1,8 @@
+import json
+
 from django.conf import settings
 from django.contrib import admin
-from django.http import JsonResponse
+from django.http import HttpResponse
 
 from import_export import resources
 from import_export.admin import ExportMixin
@@ -96,7 +98,7 @@ class ElectionSessionAdmin(admin.ModelAdmin):
                 f"{election_session.election_session_name} ElectionSession"
             ] = election_results
 
-        response = JsonResponse(election_session_results)
+        response = HttpResponse(json.dumps(election_session_results, indent='\t'))
         response.headers[
             "Content-Disposition"
         ] = "attachment; filename=ElectionResults.txt"

--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -98,7 +98,7 @@ class ElectionSessionAdmin(admin.ModelAdmin):
                 f"{election_session.election_session_name} ElectionSession"
             ] = election_results
 
-        response = HttpResponse(json.dumps(election_session_results, indent='\t'))
+        response = HttpResponse(json.dumps(election_session_results, indent="\t"))
         response.headers[
             "Content-Disposition"
         ] = "attachment; filename=ElectionResults.txt"

--- a/skule_vote/backend/admin.py
+++ b/skule_vote/backend/admin.py
@@ -96,7 +96,12 @@ class ElectionSessionAdmin(admin.ModelAdmin):
                 f"{election_session.election_session_name} ElectionSession"
             ] = election_results
 
-        return JsonResponse(election_session_results)
+        response = JsonResponse(election_session_results)
+        response.headers[
+            "Content-Disposition"
+        ] = "attachment; filename=ElectionResults.txt"
+
+        return response
 
 
 @admin.register(Election)


### PR DESCRIPTION
## Overview

- Resolves #129
- Added admin site action on `ElectionSessions` to get results for 1 or more `ElectionSessions`
- Output is a JSON response that has `NAME_OF_ELECTIONSESSION ElectionSession` as the top level keys, with the results as the value of each key. This is so that multiple `ElectionSessions` can be output at the same time.

## Unit Tests Created

- None, as this is essentially a wrapper for the `calculate_results` function from #127


## Steps to QA

- Pull
- Generate some `Elections`, etc. can use the default CSVs.
- Generate some ballots (or not, this can be tested without too since the response doesn't depend on that)
- Ensure you get a JSON response formatted as follows
```
{"Test ElectionSession": 
     { 
          "Election A": $RESULTS, 
          "Election B" $RESULTS, 
     },
"Test2 ElectionSession": 
     { 
          "Election C": $RESULTS, 
          "Election D" $RESULTS, 
     }
}

```

