### PR TITLE
Fix prompt when there are 2 candidates

### DIFF
--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -290,7 +290,9 @@ const BallotDropdowns = ({
     <>
       <Typography variant="h2">Ballot</Typography>
       <Typography variant="body1">
-        Please select as many choices as you want using the dropdown menus.
+        {candidates.length === 2
+          ? "Please select your choice using the dropdown menu."
+          : "Please select as many choices as you want using the dropdown menus."}
       </Typography>
       <SelectorDiv>
         {candidates.map(

--- a/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
@@ -31,7 +31,7 @@ describe("<BallotModal />", () => {
     expect(getByText(referendum.candidates[0].statement)).toBeInTheDocument();
     expect(queryByText("Candidates & Statements")).not.toBeInTheDocument();
     expect(getByText("Ballot")).toBeInTheDocument();
-    expect(getByText(/Please select as many/i)).toBeInTheDocument();
+    expect(getByText(/Please select your choice/i)).toBeInTheDocument();
     expect(
       getByLabelText(/Do you support this referendum?/i)
     ).toBeInTheDocument();
@@ -67,6 +67,7 @@ describe("<BallotModal />", () => {
     expect(getByText(president.election_name)).toBeInTheDocument();
     expect(getByText(president.candidates[0].statement)).toBeInTheDocument();
     expect(getByText("Candidates & Statements")).toBeInTheDocument();
+    expect(getByText(/Please select your choice/i)).toBeInTheDocument();
     expect(
       getByLabelText(/Do you support this candidate?/i)
     ).toBeInTheDocument();
@@ -94,6 +95,7 @@ describe("<BallotModal />", () => {
 
     expect(getByText(vp.election_name)).toBeInTheDocument();
     expect(getByText("Candidates & Statements")).toBeInTheDocument();
+    expect(getByText(/Please select as many/i)).toBeInTheDocument();
     for (let v of vp.candidates) {
       expect(getByText(v.name)).toBeInTheDocument();
       expect(getByText(v.statement)).toBeInTheDocument();
@@ -501,7 +503,7 @@ describe("<EnhancedBallotModal />", () => {
     expect(getByText(engsciPres.candidates[0].statement)).toBeInTheDocument();
     expect(queryByText("Candidates & Statements")).toBeInTheDocument();
     expect(getByText("Ballot")).toBeInTheDocument();
-    expect(getByText(/Please select as many/i)).toBeInTheDocument();
+    expect(getByText(/Please select your choice/i)).toBeInTheDocument();
     expect(
       getByLabelText(/Do you support this candidate?/i)
     ).toBeInTheDocument();


### PR DESCRIPTION
## Overview

- Resolves #131 
- "Please select as many choices as you want using the dropdown menus." was used when there was a Yes/No election vs an election with multiple candidates. Now if checks how many candidates there are and renders the respective prompt

Before:
<img width="539" alt="Screen Shot 2022-01-11 at 10 33 11 AM" src="https://user-images.githubusercontent.com/42653157/148977657-734e4753-3799-4d35-b4d3-de5b92b263aa.png">
<img width="552" alt="Screen Shot 2022-01-11 at 10 48 45 AM" src="https://user-images.githubusercontent.com/42653157/148977659-8af976f7-5b08-49fc-bfec-3cc3f03d5faa.png">

After: (multi candidates prompt stay the same)
<img width="412" alt="Screen Shot 2022-01-11 at 10 49 51 AM" src="https://user-images.githubusercontent.com/42653157/148977661-cf19f137-e23e-447c-aa25-7fae10bf65ec.png">


## Unit Tests Created

- Modified unit tests to check for the correct prompt


## Steps to QA

- http://localhost:8000/api/bypasscookie/
- Vote in a Case 1 and Case 2/Case 3 election and confirm the prompt makes sense given the number of candidates

