### PR TITLE
Add period to end of ruling sentence if there isn't one and a link exists

### DIFF
--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -143,6 +143,17 @@ const shuffleArray = (arr) => {
   return arr;
 };
 
+const RulingA = ({ href, children }) => (
+  <a
+    href={href}
+    style={{ color: "inherit" }}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {children}
+  </a>
+);
+
 // Orange alert that appears below candidate's name if they have a disqualification or rule violation message
 // ruling: string, link?: string ||
 export const BallotRulingAlert = ({ ruling, link }) => {
@@ -150,24 +161,23 @@ export const BallotRulingAlert = ({ ruling, link }) => {
   if (!ruling && !link) {
     message =
       "This person has been disqualified. Contact EngSoc for more information.";
+  } else if (!ruling) {
+    message = (
+      <span data-testid="ballotRulingAlert">
+        This person has been disqualified. Please read the ruling{" "}
+        <RulingA href={link}>here</RulingA>.
+      </span>
+    );
   } else {
-    ruling = ruling == null ? "" : ruling.trim();
+    ruling = ruling.trim();
+    const hasPeriod = ruling.slice(-1) === ".";
     message = (
       <span data-testid="ballotRulingAlert">
         {ruling}
         {link && (
           <span>
-            {ruling !== "" && (ruling.slice(-1) !== "." ? ". " : " ")}Please
-            read the ruling{" "}
-            <a
-              href={link}
-              style={{ color: "inherit" }}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              here
-            </a>
-            .
+            {hasPeriod ? " " : ". "}Please read the ruling{" "}
+            <RulingA href={link}>here</RulingA>.
           </span>
         )}
       </span>
@@ -176,6 +186,12 @@ export const BallotRulingAlert = ({ ruling, link }) => {
 
   return <CustomMessage variant="warning" message={message} />;
 };
+
+// ruling  link
+//   F      F     check
+//   F      T     check
+//   T      F
+//   T      T
 
 // Candidate names and statements
 // isReferendum: boolean, candidates: Array<{}>,

--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -144,14 +144,14 @@ const shuffleArray = (arr) => {
 };
 
 // Orange alert that appears below candidate's name if they have a disqualification or rule violation message
-// ruling: string, link: string
+// ruling: string, link?: string ||
 export const BallotRulingAlert = ({ ruling, link }) => {
-  ruling = ruling.trim();
   let message;
-  if (ruling === "" && link === "") {
+  if (!ruling && !link) {
     message =
       "This person has been disqualified. Contact EngSoc for more information.";
   } else {
+    ruling = ruling == null ? "" : ruling.trim();
     message = (
       <span data-testid="ballotRulingAlert">
         {ruling}

--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -148,15 +148,15 @@ const shuffleArray = (arr) => {
 const BallotRulingAlert = ({ ruling, link }) => {
   const message = (
     <>
-      {ruling}
+      {ruling.trim()}
       {link && (
         <span>
-          &nbsp;Please read the ruling&nbsp;
+          {ruling.trim().slice(-1) !== "." && "."} Please read the ruling{" "}
           <a
             href={link}
             style={{ color: "inherit" }}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             here
           </a>

--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -155,16 +155,18 @@ const RulingA = ({ href, children }) => (
 );
 
 // Orange alert that appears below candidate's name if they have a disqualification or rule violation message
-// ruling: string, link?: string ||
-export const BallotRulingAlert = ({ ruling, link }) => {
+// ruling: string, link?: string, isDQ?: bool
+export const BallotRulingAlert = ({ ruling, link, isDQ }) => {
   let message;
+  const defaultMessage = isDQ
+    ? "This candidate has been disqualified."
+    : "This candidate violated a rule.";
   if (!ruling && !link) {
-    message =
-      "This person has been disqualified. Contact EngSoc for more information.";
+    message = `${defaultMessage} Contact EngSoc for more information.`;
   } else if (!ruling) {
     message = (
       <span data-testid="ballotRulingAlert">
-        This person has been disqualified. Please read the ruling{" "}
+        {defaultMessage} Please read the ruling{" "}
         <RulingA href={link}>here</RulingA>.
       </span>
     );
@@ -183,7 +185,6 @@ export const BallotRulingAlert = ({ ruling, link }) => {
       </span>
     );
   }
-
   return <CustomMessage variant="warning" message={message} />;
 };
 
@@ -212,6 +213,7 @@ const Statements = ({ isReferendum, candidates }) => (
                 <BallotRulingAlert
                   ruling={candidate.disqualified_message}
                   link={candidate.disqualified_link}
+                  isDQ
                 />
                 <Spacer y={4} />
               </>

--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -146,25 +146,34 @@ const shuffleArray = (arr) => {
 // Orange alert that appears below candidate's name if they have a disqualification or rule violation message
 // ruling: string, link: string
 export const BallotRulingAlert = ({ ruling, link }) => {
-  const message = (
-    <span data-testid="ballotRulingAlert">
-      {ruling.trim()}
-      {link && (
-        <span>
-          {ruling.trim().slice(-1) !== "." && "."} Please read the ruling{" "}
-          <a
-            href={link}
-            style={{ color: "inherit" }}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            here
-          </a>
-          .
-        </span>
-      )}
-    </span>
-  );
+  ruling = ruling.trim();
+  let message;
+  if (ruling === "" && link === "") {
+    message =
+      "This person has been disqualified. Contact EngSoc for more information.";
+  } else {
+    message = (
+      <span data-testid="ballotRulingAlert">
+        {ruling}
+        {link && (
+          <span>
+            {ruling !== "" && (ruling.slice(-1) !== "." ? ". " : " ")}Please
+            read the ruling{" "}
+            <a
+              href={link}
+              style={{ color: "inherit" }}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              here
+            </a>
+            .
+          </span>
+        )}
+      </span>
+    );
+  }
+
   return <CustomMessage variant="warning" message={message} />;
 };
 
@@ -182,7 +191,7 @@ const Statements = ({ isReferendum, candidates }) => (
             {!isReferendum && (
               <Typography variant="h3">{candidate.name}</Typography>
             )}
-            {candidate.disqualified_message && (
+            {candidate.disqualified_status && (
               <>
                 <BallotRulingAlert
                   ruling={candidate.disqualified_message}
@@ -191,7 +200,8 @@ const Statements = ({ isReferendum, candidates }) => (
                 <Spacer y={4} />
               </>
             )}
-            {candidate.rule_violation_message && (
+            {(candidate.rule_violation_message ||
+              candidate.rule_violation_link) && (
               <>
                 <BallotRulingAlert
                   ruling={candidate.rule_violation_message}

--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -145,9 +145,9 @@ const shuffleArray = (arr) => {
 
 // Orange alert that appears below candidate's name if they have a disqualification or rule violation message
 // ruling: string, link: string
-const BallotRulingAlert = ({ ruling, link }) => {
+export const BallotRulingAlert = ({ ruling, link }) => {
   const message = (
-    <>
+    <span data-testid="ballotRulingAlert">
       {ruling.trim()}
       {link && (
         <span>
@@ -163,7 +163,7 @@ const BallotRulingAlert = ({ ruling, link }) => {
           .
         </span>
       )}
-    </>
+    </span>
   );
   return <CustomMessage variant="warning" message={message} />;
 };

--- a/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
@@ -574,13 +574,13 @@ describe("<BallotRulingAlert />", () => {
     );
   });
 
-  it("doesnt render extra period because there's no ruling message", () => {
+  it("renders default message because there's no ruling message", () => {
     const { getByTestId } = render(
       <BallotRulingAlert ruling="" link="www.link.com" />
     );
 
     expect(getByTestId("ballotRulingAlert").textContent).toEqual(
-      "Please read the ruling here."
+      "This person has been disqualified. Please read the ruling here."
     );
   });
 

--- a/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
@@ -546,7 +546,7 @@ describe("<BallotRulingAlert />", () => {
 
   it("doesnt render period because link is not included", () => {
     const { getByTestId } = render(
-      <BallotRulingAlert ruling="  This guy is bad" />
+      <BallotRulingAlert ruling="  This guy is bad" link="" />
     );
 
     expect(getByTestId("ballotRulingAlert").textContent).toEqual(
@@ -566,11 +566,31 @@ describe("<BallotRulingAlert />", () => {
 
   it("doesnt render extra period because ruling ends with one when link isnt included", () => {
     const { getByTestId } = render(
-      <BallotRulingAlert ruling="This guy is bad. " />
+      <BallotRulingAlert ruling="This guy is bad. " link="" />
     );
 
     expect(getByTestId("ballotRulingAlert").textContent).toEqual(
       "This guy is bad."
     );
+  });
+
+  it("doesnt render extra period because there's no ruling message", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="" link="www.link.com" />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "Please read the ruling here."
+    );
+  });
+
+  it("renders default message if props are empty strings", () => {
+    const { getByText } = render(<BallotRulingAlert ruling="" link="" />);
+
+    expect(
+      getByText(
+        "This person has been disqualified. Contact EngSoc for more information."
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
@@ -3,6 +3,7 @@ import { render, waitFor, fireEvent } from "@testing-library/react";
 import EnhancedBallotModal, {
   BallotModal,
   ConfirmSpoilModal,
+  BallotRulingAlert,
 } from "components/BallotModal";
 import { useHandleSubmit } from "hooks/ElectionHooks";
 import { referendum, president, vp, engsciPres } from "assets/mocks";
@@ -529,5 +530,47 @@ describe("<EnhancedBallotModal />", () => {
 
     const { container } = render(<EnhancedBallotModal {...modifiedProps} />);
     expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("<BallotRulingAlert />", () => {
+  it("renders period because ruling does not end with one and link is included", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="This guy is bad   " link="www.link.com" />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "This guy is bad. Please read the ruling here."
+    );
+  });
+
+  it("doesnt render period because link is not included", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="  This guy is bad" />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "This guy is bad"
+    );
+  });
+
+  it("doesnt render extra period because ruling ends with one when link is included", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="This guy is bad. " link="www.link.com" />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "This guy is bad. Please read the ruling here."
+    );
+  });
+
+  it("doesnt render extra period because ruling ends with one when link isnt included", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="This guy is bad. " />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "This guy is bad."
+    );
   });
 });

--- a/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/BallotModal.test.js
@@ -574,22 +574,42 @@ describe("<BallotRulingAlert />", () => {
     );
   });
 
-  it("renders default message because there's no ruling message", () => {
+  it("renders disqualified default message because there's no ruling message", () => {
+    const { getByTestId } = render(
+      <BallotRulingAlert ruling="" link="www.link.com" isDQ />
+    );
+
+    expect(getByTestId("ballotRulingAlert").textContent).toEqual(
+      "This candidate has been disqualified. Please read the ruling here."
+    );
+  });
+
+  it("renders disqualified default message if props are empty strings", () => {
+    const { getByText } = render(<BallotRulingAlert ruling="" link="" isDQ />);
+
+    expect(
+      getByText(
+        "This candidate has been disqualified. Contact EngSoc for more information."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders rule violation default message because there's no ruling message", () => {
     const { getByTestId } = render(
       <BallotRulingAlert ruling="" link="www.link.com" />
     );
 
     expect(getByTestId("ballotRulingAlert").textContent).toEqual(
-      "This person has been disqualified. Please read the ruling here."
+      "This candidate violated a rule. Please read the ruling here."
     );
   });
 
-  it("renders default message if props are empty strings", () => {
+  it("renders rule violation default message if props are empty strings", () => {
     const { getByText } = render(<BallotRulingAlert ruling="" link="" />);
 
     expect(
       getByText(
-        "This person has been disqualified. Contact EngSoc for more information."
+        "This candidate violated a rule. Contact EngSoc for more information."
       )
     ).toBeInTheDocument();
   });

--- a/skule_vote/frontend/ui/src/pages/LandingPage.js
+++ b/skule_vote/frontend/ui/src/pages/LandingPage.js
@@ -79,14 +79,18 @@ const LandingPage = () => {
           <Typography variant="body1">
             For more information about the Engineering Society and its
             elections, please visit the{" "}
-            <UrlLink href="https://skule.ca/" target="_blank" rel="noreferrer">
+            <UrlLink
+              href="https://skule.ca/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Skule
             </UrlLink>{" "}
             or{" "}
             <UrlLink
               href="https://skule.ca/page.php?q=elections"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               Elections
             </UrlLink>{" "}


### PR DESCRIPTION
## Overview

- Resolves #123
- 6 cases:
  - Message doesn't end with ".", link is provided: add an extra "."
  - Message doesn't end with ".", link is not provided: don't add an extra "."
  - Message ends with ".", link is provided: don't add an extra "."
  - Message ends with ".", link is not provided: don't add an extra "."
  - No message, link is provided: don't add an extra "."
  - No message nor link: render "This person has been disqualified. Contact EngSoc for more information."
- Also I changed all `<a>` tags to have `rel="noopener noreferrer"` which is minor but better

Before:
(Message doesn't end with ".", link is provided)
<img width="358" alt="Screen Shot 2022-01-11 at 1 08 38 PM" src="https://user-images.githubusercontent.com/42653157/148997734-a15fbeae-f561-4963-85cf-fe4f59f15a4b.png">


## Unit Tests Created

- Unit tests to cover all the period cases


## Steps to QA

- http://localhost:8000/api/bypasscookie/
- Create an election, dq a candidate. Try all 6 combinations of period/link above and make sure the message that renders looks good

