### PR TITLE
Redirect to uoft login only if we're not local

### DIFF
--- a/skule_vote/frontend/ui/src/App.js
+++ b/skule_vote/frontend/ui/src/App.js
@@ -45,6 +45,9 @@ const AppBody = styled.div`
   }
 `;
 
+export const UOFT_LOGIN =
+  "https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp";
+
 const App = () => {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
   const [isDark, setIsDark] = useLocalStorage(

--- a/skule_vote/frontend/ui/src/components/Header.js
+++ b/skule_vote/frontend/ui/src/components/Header.js
@@ -8,6 +8,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import { useGetEligibility } from "hooks/GeneralHooks";
+import { UOFT_LOGIN } from "App";
 import { ReactComponent as SkuleVoteLogo } from "images/SkuleVoteLogo.svg";
 import { responsive } from "assets/breakpoints";
 
@@ -65,6 +66,10 @@ const Header = ({ isDark, toggleDark }) => {
     </Button>
   );
 
+  const isLocal =
+    (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("localhost") ||
+    (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("127.0.0.1");
+
   return (
     <AppBar
       color={!isDark ? "primary" : "inherit"}
@@ -86,9 +91,15 @@ const Header = ({ isDark, toggleDark }) => {
             </Button>
           ) : (
             <nav>
-              <a href="https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp">
-                <Button aria-label="Vote">Vote</Button>
-              </a>
+              {isLocal ? (
+                <Link to="/elections">
+                  <Button aria-label="Vote">Vote</Button>
+                </Link>
+              ) : (
+                <a href={UOFT_LOGIN}>
+                  <Button aria-label="Vote">Vote</Button>
+                </a>
+              )}
             </nav>
           )}
         </Nav>

--- a/skule_vote/frontend/ui/src/hooks/ElectionHooks.js
+++ b/skule_vote/frontend/ui/src/hooks/ElectionHooks.js
@@ -1,6 +1,7 @@
 import { get, post } from "api/api";
 import { useSnackbar } from "notistack";
 import { statusIsGood } from "hooks/GeneralHooks";
+import { UOFT_LOGIN } from "App";
 
 export const useGetMessages = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -65,6 +66,13 @@ export const useGetEligibleElections = () => {
             }, {});
       }
     } catch (e) {
+      const isLocal =
+        (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("localhost") ||
+        (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("127.0.0.1");
+
+      if (e.response?.status === 403 && !isLocal) {
+        window.location.href = UOFT_LOGIN;
+      }
       enqueueSnackbar(
         {
           message: `Failed to fetch eligible elections: ${

--- a/skule_vote/frontend/ui/src/pages/LandingPage.js
+++ b/skule_vote/frontend/ui/src/pages/LandingPage.js
@@ -1,9 +1,11 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import Paper from "@mui/material/Paper";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { ReactComponent as SkuleLogoBlue } from "images/SkuleLogoBlue.svg";
+import { UOFT_LOGIN } from "App";
 import { responsive } from "assets/breakpoints";
 
 const SkuleLogo = styled(SkuleLogoBlue)`
@@ -69,6 +71,10 @@ const ElectionDetails = styled.div`
 `;
 
 const LandingPage = () => {
+  const isLocal =
+    (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("localhost") ||
+    (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("127.0.0.1");
+
   return (
     <>
       <LandingDiv>
@@ -95,11 +101,19 @@ const LandingPage = () => {
             </UrlLink>{" "}
             websites.
           </Typography>
-          <a href="https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp">
-            <Button color="primary" size="large" variant="contained">
-              Vote
-            </Button>
-          </a>
+          {isLocal ? (
+            <Link to="/elections">
+              <Button color="primary" size="large" variant="contained">
+                Vote
+              </Button>
+            </Link>
+          ) : (
+            <a href={UOFT_LOGIN}>
+              <Button color="primary" size="large" variant="contained">
+                Vote
+              </Button>
+            </a>
+          )}
         </LandingDivText>
       </LandingDiv>
 


### PR DESCRIPTION
## Overview

- I hope this works on prod


## Unit Tests Created

- N/a


## Steps to QA

- Go on incognito mode. On the landing page, click the "vote" button on the page or header, it should take you to /elections. not UofT login
- What should happen on prod: clicking on vote will take you to uoft login. Going directly to "/elections" should take you to uoft login

