### PR TITLE
Redirect to uoft login on a 502

### DIFF
--- a/skule_vote/frontend/ui/src/components/BallotModal.js
+++ b/skule_vote/frontend/ui/src/components/BallotModal.js
@@ -221,7 +221,7 @@ const BallotDropdowns = ({
       <Typography variant="body1">
         {candidates.length === 2
           ? "Please select your choice using the dropdown menu."
-          : "Please select as many choices as you want using the dropdown menus. Please select as many choices as you want using the dropdown menus. You are encouraged to rank all of the above choices"}
+          : "Please select as many choices as you want using the dropdown menus. Please select as many choices as you want using the dropdown menus. You are encouraged to rank all of the above choices."}
       </Typography>
       <SelectorDiv>
         {candidates.map(

--- a/skule_vote/frontend/ui/src/hooks/ElectionHooks.js
+++ b/skule_vote/frontend/ui/src/hooks/ElectionHooks.js
@@ -71,18 +71,22 @@ export const useGetEligibleElections = () => {
         (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("localhost") ||
         (process?.env?.REACT_APP_DEV_SERVER_URL ?? "").includes("127.0.0.1");
 
-      if (e.response?.status === 403 && !isLocal) {
+      if (
+        (e.response?.status === 403 || e.response?.status === 502) &&
+        !isLocal
+      ) {
         window.location.href = UOFT_LOGIN;
+      } else {
+        enqueueSnackbar(
+          {
+            message: `Failed to fetch eligible elections: ${
+              e.response?.data?.detail ?? e.message ?? e.response?.status
+            }`,
+            variant: "error",
+          },
+          { variant: "error" }
+        );
       }
-      enqueueSnackbar(
-        {
-          message: `Failed to fetch eligible elections: ${
-            e.response?.data?.detail ?? e.message ?? e.response?.status
-          }`,
-          variant: "error",
-        },
-        { variant: "error" }
-      );
     }
     return null;
   }, [enqueueSnackbar]);

--- a/skule_vote/frontend/ui/src/pages/ElectionPage.js
+++ b/skule_vote/frontend/ui/src/pages/ElectionPage.js
@@ -129,8 +129,8 @@ const ElectionPage = () => {
 
   useEffect(() => {
     async function fetchElection() {
-      const getElecSession = await getElectionSession();
       const getEligibleElecs = await getEligibleElections();
+      const getElecSession = await getElectionSession();
       const getMsgs = await getMessages();
       if (getElecSession != null) {
         setElectionSession(getElecSession);

--- a/skule_vote/frontend/ui/yarn.lock
+++ b/skule_vote/frontend/ui/yarn.lock
@@ -11383,9 +11383,9 @@ url-loader@4.1.1:
     schema-utils "^3.0.0"
 
 url-parse@^1.4.3, url-parse@^1.4.7:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
-  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
## Overview

- After #149 was merged and I tested it in prod, I noticed 2 small issues:
   - A user might get unlucky and try to go directly to the vote.skule.ca/elections after we made a push and see a 502 error
       - I made the site redirect to uoft login on a 502 response
       - Should I make the website redirect to uoft login for other status codes? @arminale 
   - The /elections page renders for less than a second before being redirected
       - I put the `enqueueSnackbar` in the else statement because it gets enqueued in that second the site renders. There's no need for it
       - I switch the order of the APIs I call so "/api/elections/" is called first, hopefully reducing the time that /elections page renders
- Also fix dependabot issue from #155 
- Also add period to end of sentence that I forgot to add in #152 


## Unit Tests Created

- n/a


## Steps to QA

- Cannot test locally :(
- You check check rn on prod, go directly to vote.skule.ca/elections in incognito, and see the /elections page flash for a second before you are redirected

