### PR TITLE
Fix broken unit tests caused by #149

### DIFF
--- a/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
@@ -25,6 +25,7 @@ describe("<Header />", () => {
   });
 
   it("renders Header on landing page on local", () => {
+    process.env.REACT_APP_DEV_SERVER_URL = "http://localhost:8000";
     const { getByText, queryByText, getByTestId } = render(
       withRouter(<Header />, "/")
     );
@@ -43,7 +44,7 @@ describe("<Header />", () => {
   });
 
   it("renders Header on landing page on prod", () => {
-    process.env.REACT_APP_DEV_SERVER_URL = "not local";
+    process.env.REACT_APP_DEV_SERVER_URL = "vote.skule.ca";
     const { getByText, queryByText, getByTestId } = render(
       withRouter(<Header />, "/")
     );

--- a/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
@@ -13,7 +13,37 @@ jest.mock("hooks/GeneralHooks", () => ({
 }));
 
 describe("<Header />", () => {
-  it("renders Header on landing page", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  it("renders Header on landing page on local", () => {
+    const { getByText, queryByText, getByTestId } = render(
+      withRouter(<Header />, "/")
+    );
+    expect(getByTestId("skuleVoteLogo")).toBeInTheDocument();
+    expect(getByTestId("darkLightModeIcon")).toBeInTheDocument();
+    expect(getByText("Vote")).toBeInTheDocument();
+    expect(queryByText("Check eligibility")).not.toBeInTheDocument();
+    expect(getByTestId("skuleVoteLogo").closest("a")).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(getByText("Vote").closest("a")).toHaveAttribute(
+      "href",
+      "/elections"
+    );
+  });
+
+  it("renders Header on landing page on prod", () => {
+    process.env.REACT_APP_DEV_SERVER_URL = "not local";
     const { getByText, queryByText, getByTestId } = render(
       withRouter(<Header />, "/")
     );

--- a/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
+++ b/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
@@ -4,7 +4,31 @@ import { withRouter } from "assets/testing";
 import LandingPage from "../LandingPage";
 
 describe("<LandingPage />", () => {
-  it("renders landing page", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  it("renders landing page on local", () => {
+    const { getByText, getByTestId } = render(withRouter(<LandingPage />));
+    expect(getByText("Welcome to SkuleVote")).toBeInTheDocument();
+    expect(getByText("Election Details")).toBeInTheDocument();
+    expect(getByText(/Single Transferable Vote system/i)).toBeInTheDocument();
+    expect(getByTestId("skuleLogo")).toBeInTheDocument();
+    expect(getByText("Vote").closest("a")).toHaveAttribute(
+      "href",
+      "/elections"
+    );
+  });
+
+  it("renders landing page on prod", () => {
+    process.env.REACT_APP_DEV_SERVER_URL = "not local";
     const { getByText, getByTestId } = render(withRouter(<LandingPage />));
     expect(getByText("Welcome to SkuleVote")).toBeInTheDocument();
     expect(getByText("Election Details")).toBeInTheDocument();

--- a/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
+++ b/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
@@ -16,6 +16,7 @@ describe("<LandingPage />", () => {
   });
 
   it("renders landing page on local", () => {
+    process.env.REACT_APP_DEV_SERVER_URL = "http://localhost:8000";
     const { getByText, getByTestId } = render(withRouter(<LandingPage />));
     expect(getByText("Welcome to SkuleVote")).toBeInTheDocument();
     expect(getByText("Election Details")).toBeInTheDocument();
@@ -28,7 +29,7 @@ describe("<LandingPage />", () => {
   });
 
   it("renders landing page on prod", () => {
-    process.env.REACT_APP_DEV_SERVER_URL = "not local";
+    process.env.REACT_APP_DEV_SERVER_URL = "vote.skule.ca";
     const { getByText, getByTestId } = render(withRouter(<LandingPage />));
     expect(getByText("Welcome to SkuleVote")).toBeInTheDocument();
     expect(getByText("Election Details")).toBeInTheDocument();


### PR DESCRIPTION
## Overview

- Tests were failing locally but not on Github because the environment variables changed


## Unit Tests Created

- Create unit tests to check if we are directing to /elections (on local) or to uoft login (on prod)


## Steps to QA

- n/a

