### PR TITLE
Fixed Unit Tests not running due to Daylight Savings Time

### DIFF
--- a/skule_vote/backend/test_admin.py
+++ b/skule_vote/backend/test_admin.py
@@ -42,8 +42,8 @@ class ElectionSessionAdminTestCase(SetupMixin, TestCase):
             kwargs={"object_id": election_session.id},
         )
 
-        new_start = self._now() + timedelta(days=5)
-        new_end = self._now() + timedelta(days=10)
+        new_start = (self._now() + timedelta(days=5)).astimezone(settings.TZ_INFO)
+        new_end = (self._now() + timedelta(days=10)).astimezone(settings.TZ_INFO)
         new_data = {
             "election_session_name": "ElectionSession2021Part2",
             "start_time_0": new_start.date(),
@@ -76,7 +76,7 @@ class ElectionSessionAdminTestCase(SetupMixin, TestCase):
             kwargs={"object_id": election_session.id},
         )
 
-        new_end = self._now() + timedelta(days=10)
+        new_end = (self._now() + timedelta(days=10)).astimezone(settings.TZ_INFO)
         new_data = {
             "election_session_name": self.data["election_session_name"],
             "start_time_0": self.data["start_time"].date(),


### PR DESCRIPTION
## Overview

- Resolves broken unit tests
- In our unit tests we test the ability to change the start or end time of an `ElectionSession` after it was created. 
- This was done using `new_end = self._now() + timedelta(days=10)`. 
- However, when daylight savings time approaches, what might happen is as follows:
   -  The `self._now()` may return a date with a timezone in `UTC-5` space
   - Adding the `timedelta` would cause the variable `new_end` to have a date with a timezone in `UTC-4` space
   - However, the timezone of `new_end` will still be `UTC-5` since `timedelta` does not update the timezone
   - Then, we get the `end_time` for the `ElectionSession` as `election_session.end_time.astimezone(settings.TZ_INFO)`. This is timezone-aware, so it is in the correct timezone. 
   - When we want to compare the `end_time` with the `new_end` for example, it fails because `new_end` has the incorrect timezone.

## Unit Tests Fixed

- Two unit tests were broken due to the incorrect timezone issue.
- Fixed issue by adding  `.astimezone(settings.TZ_INFO)` to the `new_end` and `new_start` variables that required a check 


## Steps to QA

- Run the unit tests, make sure they work
- Make sure you understand what I fixed

