### PR TITLE
Fixed gunicorn timeout by adding timeout parameter of 120s

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       dockerfile: ./deployment/Dockerfile
-    command: gunicorn skule_vote.wsgi:application --bind 0.0.0.0:8001 --workers 5 --capture-output --access-logfile - --error-logfile -
+    command: gunicorn skule_vote.wsgi:application --bind 0.0.0.0:8001 --workers 5 --timeout 120 --capture-output --access-logfile - --error-logfile -
     ports:
       - 8001:8001
     env_file: ENV_VARS


### PR DESCRIPTION
## Overview

- Resolves issue with website crashing when calculating election results
  - The issue was that Gunicorn was timing out
  - Fixed the issue by adding a 120s timeout instead of the current one of ~45s using `--timeout 120` in the docker-compose file.

## Unit Tests Created

- N/A


## Steps to QA

- Can't really QA, see [here](https://stackoverflow.com/questions/10855197/gunicorn-worker-timeout-error) for fix source and check if I'm making sense 

