### PR TITLE
SHA256 & UOFT_LOGIN Link Updates

### DIFF
--- a/skule_vote/backend/views.py
+++ b/skule_vote/backend/views.py
@@ -83,7 +83,7 @@ def _create_verified_voter(query_dict, verify_hash=True):
             + settings.UOFT_SECRET_KEY
         )
         encoded_check_string = check_string.encode(encoding="utf-8")
-        h = hashlib.md5()
+        h = hashlib.sha256()
         h.update(encoded_check_string)
         check_hash = h.hexdigest()
 

--- a/skule_vote/frontend/ui/src/App.js
+++ b/skule_vote/frontend/ui/src/App.js
@@ -50,7 +50,7 @@ const AppBody = styled("div")(({ theme }) => ({
 }));
 
 export const UOFT_LOGIN =
-  "https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp";
+  "https://portal.engineering.utoronto.ca/weblogin/sites/voting/vote.aspx";
 
 const App = () => {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");

--- a/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
+++ b/skule_vote/frontend/ui/src/components/__tests__/Header.test.js
@@ -58,7 +58,7 @@ describe("<Header />", () => {
     );
     expect(getByText("Vote").closest("a")).toHaveAttribute(
       "href",
-      "https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp"
+      "https://portal.engineering.utoronto.ca/weblogin/sites/voting/vote.aspx"
     );
   });
 

--- a/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
+++ b/skule_vote/frontend/ui/src/pages/__tests__/LandingPage.test.js
@@ -37,7 +37,7 @@ describe("<LandingPage />", () => {
     expect(getByTestId("skuleLogo")).toBeInTheDocument();
     expect(getByText("Vote").closest("a")).toHaveAttribute(
       "href",
-      "https://portal.engineering.utoronto.ca/weblogin/sites/apsc/vote.asp"
+      "https://portal.engineering.utoronto.ca/weblogin/sites/voting/vote.aspx"
     );
   });
 });


### PR DESCRIPTION
## Overview

- Resolves #189
- Updates site to use SHA256 for hashes from UofT, instead of previously used MD5
- Updates links to UofT login that were changed as a result of the change on UofT's backend

## Unit Tests Created

- Updated unit tests for frontend to reflect new link


## Steps to QA

- Run unit tests (both FE and BE)
- Click the link to make sure it sends you to the login and not an error page

